### PR TITLE
Add a basic, hard-coded field in the request so that Legato only request...

### DIFF
--- a/lib/legato/query.rb
+++ b/lib/legato/query.rb
@@ -3,6 +3,7 @@ module Legato
     include Enumerable
 
     MONTH = 2592000
+    REQUEST_FIELDS = 'columnHeaders/name,rows,totalResults,totalsForAllResults'
 
     def define_filter(name, &block)
       (class << self; self; end).instance_eval do
@@ -180,7 +181,8 @@ module Legato
         'max-results' => limit,
         'start-index' => offset,
         # 'segment' => segment_id,
-        'filters' => filters.to_params # defaults to AND filtering
+        'filters' => filters.to_params, # defaults to AND filtering
+        'fields' => REQUEST_FIELDS
       }
 
       [metrics, dimensions, sort].each do |list|

--- a/spec/lib/legato/query_spec.rb
+++ b/spec/lib/legato/query_spec.rb
@@ -289,6 +289,7 @@ describe Legato::Query do
         @query.to_params.should == {
           'ids' => 'ga:1234567890',
           'start-date' => Legato.format_time(Time.now-Legato::Query::MONTH),
+          'fields' => Legato::Query::REQUEST_FIELDS,
           'end-date' => Legato.format_time(Time.now)
         }
       end
@@ -297,7 +298,11 @@ describe Legato::Query do
         now = Time.now
         @query.start_date = now
         @query.end_date = now
-        @query.to_params.should == {'start-date' => Legato.format_time(now), 'end-date' => Legato.format_time(now)}
+        @query.to_params.should == {
+          'start-date' => Legato.format_time(now),
+          'fields' => Legato::Query::REQUEST_FIELDS,
+          'end-date' => Legato.format_time(now)
+        }
       end
 
       it 'includes the limit' do


### PR DESCRIPTION
...s the set of data Legato will parse on the response. This reduces the size of the response and consequently reduces parsing time.

The current set of fields are:
columnHeaders/name
rows
totalResults
totalForAllResults

In the future this could be made to be configurable in some manner.
