### PR TITLE
Explicitly require ActiveSupport core extensions

### DIFF
--- a/lib/legato.rb
+++ b/lib/legato.rb
@@ -4,7 +4,10 @@ require 'multi_json'
 require 'cgi'
 require 'ostruct'
 
-unless Object.const_defined?("ActiveSupport")
+if Object.const_defined?("ActiveSupport")
+  require "active_support/core_ext/string"
+  require "active_support/core_ext/array"
+else
   require "legato/core_ext/string"
   require "legato/core_ext/array"
 end


### PR DESCRIPTION
Without these explicit require statements, core extensions are sometimes not loaded, e.g. when a standalone (non Active Record or Active Resource-inherited) class is used to encapsulate Legato models.
