### PR TITLE
Adding unit tests to the Array Core Extension

### DIFF
--- a/spec/lib/legato/core_ext/array_spec.rb
+++ b/spec/lib/legato/core_ext/array_spec.rb
@@ -63,7 +63,7 @@ describe Array, 'Core Extension Methods' do
     end
 
     it "returns a hash in an array" do
-      subject.wrap({ data: [1,2] }).should == [{ data: [1,2] }]
+      subject.wrap({ :data => [1,2] }).should == [{ :data => [1,2] }]
     end
   end
 end


### PR DESCRIPTION
As I get more familiar with legato, I would like to start getting some basic unit tests around the core extensions that are used if `ActiveSupport` is not available.

This tests the `Array.wrap`
- When an object is nil
- When an object does not have `to_ary` defined
- When an object has `to_ary` defined
- General methods handling some of the different types (hash, integer, float, string, array, etc)
