### PR TITLE
Hide config instructions if config file already exists

### DIFF
--- a/lib/legato/cli.rb
+++ b/lib/legato/cli.rb
@@ -26,10 +26,10 @@ module Legato
 
   class CLI
     def initialize
-      path = File.join(ENV['HOME'], '.legato.yml')
+      config_path = File.join(ENV['HOME'], '.legato.yml')
 
-      if File.exists?(path)
-        @config = YAML.load_file(path) rescue {}
+      if File.exists?(config_path)
+        @config = YAML.load_file(config_path) rescue {}
       else
         puts "##########################################################"
         puts "We can auto-load OAuth2 config from ~/.legato.yml"
@@ -40,7 +40,7 @@ module Legato
 
       build_access_token
 
-      print_yaml unless File.exists?(path)
+      print_yaml unless File.exists?(config_path)
     end
 
     def run


### PR DESCRIPTION
I was confused when—after creating a `~/.librato.yml` file—I still was shown the message to create one.

I initially though that I'd somehow saved it wrong.

I think that removing the message entirely when loading from config is more straightforward.
