### PR TITLE
Don't add multiple times metrics and dimensions

### DIFF
--- a/lib/legato/list_parameter.rb
+++ b/lib/legato/list_parameter.rb
@@ -18,6 +18,11 @@ module Legato
       self
     end
 
+    def |(element)
+      (@elements |= Array.wrap(element)).compact!
+      self
+    end
+
     def to_params
       value = elements.map{|element| Legato.to_ga_string(element, tracking_scope)}.join(',')
       value.empty? ? {} : {name => value}

--- a/lib/legato/list_parameter.rb
+++ b/lib/legato/list_parameter.rb
@@ -1,11 +1,11 @@
 module Legato
   class ListParameter
 
-    attr_reader :name, :elements, :tracking_scope
+    attr_reader :name, :tracking_scope
 
     def initialize(name, elements=[], tracking_scope = "ga")
       @name = name
-      @elements = Array.wrap(elements)
+      @elements = Set.new Array.wrap(elements).compact
       @tracking_scope = tracking_scope
     end
 
@@ -14,13 +14,12 @@ module Legato
     end
 
     def <<(element)
-      (@elements += Array.wrap(element)).compact!
+      @elements += Array.wrap(element).compact
       self
     end
 
-    def |(element)
-      (@elements |= Array.wrap(element)).compact!
-      self
+    def elements
+      @elements.to_a
     end
 
     def to_params

--- a/lib/legato/model.rb
+++ b/lib/legato/model.rb
@@ -11,7 +11,7 @@ module Legato
     def metrics(*fields)
       fields, options = options_from_fields(fields)
       @metrics ||= ListParameter.new(:metrics, [], options.fetch(:tracking_scope, "ga"))
-      @metrics << fields
+      @metrics |= fields
     end
 
     # Adds dimensions to the class for retrieval from GA
@@ -21,7 +21,7 @@ module Legato
     def dimensions(*fields)
       fields, options = options_from_fields(fields)
       @dimensions ||= ListParameter.new(:dimensions, [], options.fetch(:tracking_scope, "ga"))
-      @dimensions << fields
+      @dimensions |= fields
     end
 
     def filters

--- a/lib/legato/model.rb
+++ b/lib/legato/model.rb
@@ -11,7 +11,7 @@ module Legato
     def metrics(*fields)
       fields, options = options_from_fields(fields)
       @metrics ||= ListParameter.new(:metrics, [], options.fetch(:tracking_scope, "ga"))
-      @metrics |= fields
+      @metrics << fields
     end
 
     # Adds dimensions to the class for retrieval from GA
@@ -21,7 +21,7 @@ module Legato
     def dimensions(*fields)
       fields, options = options_from_fields(fields)
       @dimensions ||= ListParameter.new(:dimensions, [], options.fetch(:tracking_scope, "ga"))
-      @dimensions |= fields
+      @dimensions << fields
     end
 
     def filters
@@ -61,7 +61,7 @@ module Legato
     end
 
     # Set the class used to make new instances of returned results from GA
-    # 
+    #
     # @param klass [Class] any class that accepts a hash of attributes to
     #   initialize the values of the class
     # @return the original class given
@@ -74,7 +74,7 @@ module Legato
     end
 
     # Builds a `query` to get results from GA
-    # 
+    #
     # @param profile [Legato::Management::Profile] the profile to query GA against
     # @param options [Hash] options:
     #   * start_date
@@ -92,7 +92,7 @@ module Legato
     end
 
     # Builds a `query` and sets the `realtime` property
-    # 
+    #
     # @return [Query] a new query with `realtime` property set
     def realtime
       Query.new(self).realtime

--- a/spec/lib/legato/model_spec.rb
+++ b/spec/lib/legato/model_spec.rb
@@ -22,6 +22,13 @@ describe "Legato::Model" do
       @model.metrics.should == Legato::ListParameter.new(:metrics, [:exits, :pageviews])
     end
 
+    it 'does not add duplicated metrics' do
+      @model.metrics :exits
+      @model.metrics :exits
+      @model.metrics :exits, :exits
+      @model.metrics.should == Legato::ListParameter.new(:metrics, [:exits])
+    end
+
     it 'has a dimension' do
       @model.dimensions :browser
       @model.dimensions.should == Legato::ListParameter.new(:dimensions, [:browser])
@@ -30,6 +37,13 @@ describe "Legato::Model" do
     it 'has dimensions' do
       @model.dimensions :browser, :city
       @model.dimensions.should == Legato::ListParameter.new(:dimensions, [:browser, :city])
+    end
+
+    it 'does not add duplicated dimensions' do
+      @model.dimensions :browser
+      @model.dimensions :browser
+      @model.dimensions :browser, :browser
+      @model.dimensions.should == Legato::ListParameter.new(:dimensions, [:browser])
     end
 
     it 'knows the instance class it should use' do


### PR DESCRIPTION
I've changed the method that adds dimensions a metrics to only add them once. I had to change also the `ListParameter` class to be able to use the `|=` way of adding things to array only once.