### PR TITLE
Adds support for string formatted dates

### DIFF
--- a/lib/legato.rb
+++ b/lib/legato.rb
@@ -25,7 +25,11 @@ module Legato
   end
 
   def self.format_time(t)
-    t.strftime('%Y-%m-%d')
+    if t.is_a?(String)
+      t
+    else
+      t.strftime('%Y-%m-%d')
+    end
   end
 
   def self.and_join_character

--- a/spec/lib/legato/query_spec.rb
+++ b/spec/lib/legato/query_spec.rb
@@ -386,6 +386,17 @@ describe Legato::Query do
         }
       end
 
+      it "supports string formatted dates" do
+        @query.start_date = "2014-01-01"
+        @query.end_date = "yesterday"
+
+        @query.to_params.should == {
+          'start-date' => "2014-01-01",
+          'end-date' => "yesterday",
+          'fields' => Legato::Query::REQUEST_FIELDS,
+        }
+      end
+
       it 'includes the limit' do
         @query.limit = 1000
         @query.to_params['max-results'].should == 1000


### PR DESCRIPTION
This gives more flexibility to use directly values supported by the
Analytics Core Reporting API.
See start-date and end-date specs under https://developers.google.com/analytics/devguides/reporting/core/v3/reference#q_summary