### PR TITLE
Correct weird use of lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Return entries with exits counts greater than or equal to 2000
 
 ```ruby
 filter(:high_exits) {gte(:exits, 2000)}
+
+# or ...
+
+filter :high_exits, &lambda {gte(:exits, 2000)}
 ```
 
 Return entries with pageview metric less than or equal to 200

--- a/README.md
+++ b/README.md
@@ -103,25 +103,25 @@ Inside of any `Legato::Model` class, the method `filter` is available (like `met
 Return entries with exits counts greater than or equal to 2000
 
 ```ruby
-filter :high_exits, &lambda {gte(:exits, 2000)}
+filter(:high_exits) {gte(:exits, 2000)}
 ```
 
 Return entries with pageview metric less than or equal to 200
 
 ```ruby
-filter :low_pageviews, &lambda {lte(:pageviews, 200)}
+filter(:low_pageviews) {lte(:pageviews, 200)}
 ```
 
 Filters with dimensions
 
 ```ruby
-filter :for_browser, &lambda {|browser| matches(:browser, browser)}
+filter(:for_browser) {|browser| matches(:browser, browser)}
 ```
 
 Filters with OR
 
 ```ruby
-filter :browsers, &lambda {|*browsers| browsers.map {|browser| matches(:browser, browser)}}
+filter(:browsers) {|*browsers| browsers.map {|browser| matches(:browser, browser)}}
 ```
 
 
@@ -162,7 +162,7 @@ Be sure to pass the appropriate number of arguments matching the lambda for your
 For a filter defined like this:
 
 ```ruby
-filter :browsers, &lambda {|*browsers| browsers.map {|browser| matches(:browser, browser)}}
+filter(:browsers) {|*browsers| browsers.map {|browser| matches(:browser, browser)}}
 ```
 
 We can use it like this, passing any number of arguments:


### PR DESCRIPTION
Usually, `lambda` in Ruby is used to **save in a variable and reuse** the block.
If you don't need to reuse, use ordinary block.

I was surprised that many posts about this gem adapts such ways of `lambda`.