### PR TITLE
Adding segment_id

### DIFF
--- a/lib/legato/model.rb
+++ b/lib/legato/model.rb
@@ -81,6 +81,7 @@ module Legato
     #   * offset
     #   * sort
     #   * quota_user
+    #   * segment_id
     # @return [Query] a new query with all the filters/segments defined on the
     #   model, allowing for chainable behavior before kicking of the request
     #   to Google Analytics which returns the result data

--- a/lib/legato/query.rb
+++ b/lib/legato/query.rb
@@ -29,7 +29,7 @@ module Legato
 
     attr_reader :parent_klass
     attr_accessor :profile, :start_date, :end_date
-    attr_accessor :sort, :limit, :offset, :quota_user, :sampling_level #, :segment # individual, overwritten
+    attr_accessor :sort, :limit, :offset, :quota_user, :sampling_level, :segment_id #, :segment # individual, overwritten
     attr_accessor :filters, :segment_filters # combined, can be appended to
     attr_accessor :tracking_scope
 
@@ -91,7 +91,7 @@ module Legato
     end
 
     def apply_basic_options(options)
-      [:sort, :limit, :offset, :start_date, :end_date, :quota_user, :sampling_level].each do |key| #:segment
+      [:sort, :limit, :offset, :start_date, :end_date, :quota_user, :sampling_level, :segment_id].each do |key| #:segment
         self.send("#{key}=".to_sym, options[key]) if options.has_key?(key)
       end
     end
@@ -189,9 +189,9 @@ module Legato
       "sessions::condition::#{segment_filters.to_params}" if segment_filters.any?
     end
 
-    # def segment_id
-    #   segment.nil? ? nil : "gaid::#{segment}"
-    # end
+    def segment_id=(segment_id)
+      @segment_id = "gaid::#{segment_id}"
+    end
 
     def profile_id
       profile && Legato.to_ga_string(profile.id)
@@ -213,7 +213,7 @@ module Legato
         'end-date' => Legato.format_time(end_date),
         'max-results' => limit,
         'start-index' => offset,
-        'segment' => segment,
+        'segment' => segment_id || segment,
         'filters' => filters.to_params, # defaults to AND filtering
         'fields' => REQUEST_FIELDS,
         'quotaUser' => quota_user,

--- a/spec/lib/legato/query_spec.rb
+++ b/spec/lib/legato/query_spec.rb
@@ -323,6 +323,12 @@ describe Legato::Query do
         @query.quota_user.should == 'an id'
       end
 
+      it "sets the segment_id" do
+        segment_id = '123122534'
+        @query.apply_options({:segment_id => segment_id})
+        @query.segment_id.should == "gaid::#{segment_id}"
+      end
+
       context "with Time" do
         before :each do
           @now = Time.now
@@ -437,6 +443,20 @@ describe Legato::Query do
         @query.stubs(:segment_filters).returns(segment_filters)
 
         @query.to_params['segment'].should == 'sessions::condition::ga::parameter'
+      end
+
+      it 'includes segment_id' do
+        @query.stubs(:segment_id).returns('gaid::12453453')
+
+        @query.to_params['segment'].should == 'gaid::12453453'
+      end
+
+      it 'includes segment_id and segment_filters' do
+        segment_filters = stub(:to_params => 'ga::parameter', :any? => true)
+        @query.stubs(:segment_filters).returns(segment_filters)
+        @query.stubs(:segment_id).returns('gaid::12453453')
+
+        @query.to_params['segment'].should == 'gaid::12453453'
       end
 
       it 'includes metrics' do


### PR DESCRIPTION
This pull request adds the ability to query by segment_id using this [doc](https://developers.google.com/analytics/devguides/reporting/core/v3/reference#segment) as reference.
Since segment_id is passed as a param to the model, it will override previously set segment filters.