### PR TITLE
Set an empty array when web property has no profile

### DIFF
--- a/lib/legato/management/web_property.rb
+++ b/lib/legato/management/web_property.rb
@@ -42,6 +42,7 @@ module Legato
 
       def self.build_from_summary(attributes, user, account)
         profiles = attributes.delete('profiles') || attributes.delete(:profiles)
+        profiles ||= []
 
         WebProperty.new(attributes, user).tap { |web_property|
           web_property.account = account

--- a/lib/legato/management/web_property.rb
+++ b/lib/legato/management/web_property.rb
@@ -41,8 +41,7 @@ module Legato
       end
 
       def self.build_from_summary(attributes, user, account)
-        profiles = attributes.delete('profiles') || attributes.delete(:profiles)
-        profiles ||= []
+        profiles = attributes.delete('profiles') || attributes.delete(:profiles) || []
 
         WebProperty.new(attributes, user).tap { |web_property|
           web_property.account = account

--- a/spec/lib/legato/management/account_summary_spec.rb
+++ b/spec/lib/legato/management/account_summary_spec.rb
@@ -50,6 +50,14 @@ describe Legato::Management::AccountSummary do
               :type => "WEB4"
             }
           ]
+        },
+        {
+          :kind => "analytics#webPropertySummary",
+          :id => "UA-3",
+          :name => "WebProperty3",
+          :internalWebPropertyId => 789,
+          :level => "STANDARD",
+          :websiteUrl => "http://www.google.com"
         }
       ]
     }
@@ -86,18 +94,24 @@ describe Legato::Management::AccountSummary do
     end
 
     it "builds the web_properties instances" do
-      account_summary.web_properties.size.should == 2
+      account_summary.web_properties.size.should == 3
       account_summary.web_properties.first.attributes[:kind].should == "analytics#webPropertySummary"
       account_summary.web_properties.first.id.should == "UA-1"
       account_summary.web_properties.first.name.should == "WebProperty1"
       account_summary.web_properties.first.account_id.should == 12345
       account_summary.web_properties.first.attributes[:internalWebPropertyId].should == 123
       account_summary.web_properties.first.attributes[:level].should == "STANDARD"
+      account_summary.web_properties[1].attributes[:kind].should == "analytics#webPropertySummary"
+      account_summary.web_properties[1].id.should == "UA-2"
+      account_summary.web_properties[1].name.should == "WebProperty2"
+      account_summary.web_properties[1].account_id.should == 12345
+      account_summary.web_properties[1].attributes[:internalWebPropertyId].should == 456
+      account_summary.web_properties[1].attributes[:level].should == "STANDARD"
       account_summary.web_properties.last.attributes[:kind].should == "analytics#webPropertySummary"
-      account_summary.web_properties.last.id.should == "UA-2"
-      account_summary.web_properties.last.name.should == "WebProperty2"
+      account_summary.web_properties.last.id.should == "UA-3"
+      account_summary.web_properties.last.name.should == "WebProperty3"
       account_summary.web_properties.last.account_id.should == 12345
-      account_summary.web_properties.last.attributes[:internalWebPropertyId].should == 456
+      account_summary.web_properties.last.attributes[:internalWebPropertyId].should == 789
       account_summary.web_properties.last.attributes[:level].should == "STANDARD"
     end
 
@@ -157,6 +171,7 @@ describe Legato::Management::AccountSummary do
       account_summary.web_properties[0].profiles[2].id.should == 1236
       account_summary.web_properties[1].profiles.size.should == 1
       account_summary.web_properties[1].profiles[0].id.should == 1237
+      account_summary.web_properties[2].profiles.size.should == 0
     end
 
     it "can be used for traversing to web_properties from accounts" do


### PR DESCRIPTION
I've add a line to simply set an empty array for avoiding an exception by invoking methods on `nil` .

Since you can remove all profiles from a web property in Google Analytics console, an exception [ `NoMethodError (undefined method 'map' for nil:NilClass` ] might occur on fetching account summary.

```ruby
        WebProperty.new(attributes, user).tap { |web_property|
          web_property.account = account
          web_property.profiles = profiles.map { |profile| # <= NoMethodError on this line
            profile['accountId'] = account.id
            profile['webPropertyId'] = web_property.id
            Profile.build_from_summary(profile, user, account, web_property)
          }
        }
```