### PR TITLE
Add license info to the gemspec.

### DIFF
--- a/legato.gemspec
+++ b/legato.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/tpitale/legato"
   s.summary     = %q{Access the Google Analytics API with Ruby}
   s.description = %q{Access the Google Analytics Core Reporting and Management APIs with Ruby. Create models for metrics and dimensions. Filter your data to tell you what you need.}
+  s.license     = "MIT"
 
   s.rubyforge_project = "legato"
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.